### PR TITLE
Kevin H: challenge changes

### DIFF
--- a/src/main/java/com/midwesttape/project/challengeapplication/dao/AddressDao.java
+++ b/src/main/java/com/midwesttape/project/challengeapplication/dao/AddressDao.java
@@ -1,0 +1,32 @@
+package com.midwesttape.project.challengeapplication.dao;
+
+import com.midwesttape.project.challengeapplication.model.Address;
+import com.midwesttape.project.challengeapplication.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Created this as a {@link UserService} equivalent but for {@link Address} instead,
+ * just in case this was being looked for.
+ */
+@Repository
+@RequiredArgsConstructor
+public class AddressDao {
+
+    private final JdbcTemplate template;
+
+    public Address getAddress(long id) {
+        try {
+            return template.queryForObject(
+                    "select * from Address where id = ?",
+                    new BeanPropertyRowMapper<>(Address.class),
+                    id
+            );
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/midwesttape/project/challengeapplication/model/Address.java
+++ b/src/main/java/com/midwesttape/project/challengeapplication/model/Address.java
@@ -1,0 +1,15 @@
+package com.midwesttape.project.challengeapplication.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class Address {
+    private Long id;
+    private String address1;
+    private String address2;
+    private String city;
+    private String state;
+    private String postal;
+}

--- a/src/main/java/com/midwesttape/project/challengeapplication/model/User.java
+++ b/src/main/java/com/midwesttape/project/challengeapplication/model/User.java
@@ -1,6 +1,8 @@
 package com.midwesttape.project.challengeapplication.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.ToString;
 import lombok.experimental.Accessors;
 
 @Data
@@ -10,5 +12,9 @@ public class User {
     private String firstName;
     private String lastName;
     private String username;
+    // Deserialize, but no accidental serialization, including toString in case of any logging of the object.
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @ToString.Exclude
     private String password;
+    private Address address;
 }

--- a/src/main/java/com/midwesttape/project/challengeapplication/model/mapper/UserRowMapper.java
+++ b/src/main/java/com/midwesttape/project/challengeapplication/model/mapper/UserRowMapper.java
@@ -1,0 +1,66 @@
+package com.midwesttape.project.challengeapplication.model.mapper;
+
+import com.midwesttape.project.challengeapplication.model.Address;
+import com.midwesttape.project.challengeapplication.model.User;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+
+/**
+ * A {@link BeanPropertyRowMapper} that maps to a {@link User} and also to its' nested
+ * {@link Address}, instead of inefficiently querying the database individually for
+ * each entity.
+ */
+public class UserRowMapper extends BeanPropertyRowMapper<User> {
+
+    /**
+     * Default query this mapper is able to handle.
+     */
+    public static String SELECT_QUERY = "select " +
+                "u.id, " +
+                "u.firstName, " +
+                "u.lastName, " +
+                "u.username, " +
+                "u.password, " +
+                "a.id address_id, " +
+                "a.address1, " +
+                "a.address2, " +
+                "a.city, " +
+                "a.state, " +
+                "a.postal " +
+            "from User u " +
+            "join Address a " +
+            "on u.address_id = a.id " +
+            "where u.id = ?";
+
+    public UserRowMapper() {
+        super(User.class);
+    }
+
+    @Override
+    public User mapRow(ResultSet rs, int rowNumber) throws SQLException {
+        User user = super.mapRow(rs, rowNumber);
+        if (user == null) {
+            return null;
+        }
+
+        Address address = new Address();
+        address.setId(rs.getLong("address_id"));
+
+        // A glaring issue with the ResultSet api is returning 0 when a value is null on numeric types.
+        // Luckily the defined schema forbids nulls on address_id, but it's better to be safe than sorry.
+        if (rs.wasNull()) {
+            throw new SQLIntegrityConstraintViolationException("Incorrect relation, check foreign keys on User: " + user.getId());
+        }
+        address.setAddress1(rs.getString("address1"));
+        address.setAddress2(rs.getString("address2"));
+        address.setCity(rs.getString("city"));
+        address.setState(rs.getString("state"));
+        address.setPostal(rs.getString("postal"));
+        user.setAddress(address);
+
+        return user;
+    }
+}

--- a/src/main/java/com/midwesttape/project/challengeapplication/rest/UserController.java
+++ b/src/main/java/com/midwesttape/project/challengeapplication/rest/UserController.java
@@ -4,18 +4,41 @@ import com.midwesttape.project.challengeapplication.model.User;
 import com.midwesttape.project.challengeapplication.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/v1/users")
 public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/v1/users/{userId}")
+    @GetMapping("/{userId}")
     public User user(@PathVariable final Long userId) {
         return userService.user(userId);
     }
 
+    /**
+     * Could be a {@link PatchMapping} since it's only updating part of a user. I went with PUT because:
+     * <ul>
+     *     <li>{@code id} cannot change</li>
+     *     <li>{@code password} should have it's own /change-pass endpoint</li>
+     *     <li>the related address should be updated on a separate controller/endpoint</li>
+     *     <li>PUT seems more common to me, and we are updating the whole object if we ignore the intentionally omitted fields</li>
+     * </ul>
+     *
+     * Example cli test:
+     * <pre>
+     * $ jo firstName=Bart lastName=Simpson username=bsimpson | curl --json @- -X PUT localhost:8080/v1/users/1
+     * </pre>
+     */
+    @PutMapping("/{userId}")
+    public void updateUser(@PathVariable final Long userId, @RequestBody User user) {
+        userService.updateUser(userId, user);
+    }
 }

--- a/src/main/java/com/midwesttape/project/challengeapplication/service/UserService.java
+++ b/src/main/java/com/midwesttape/project/challengeapplication/service/UserService.java
@@ -1,9 +1,12 @@
 package com.midwesttape.project.challengeapplication.service;
 
 import com.midwesttape.project.challengeapplication.model.User;
+import com.midwesttape.project.challengeapplication.model.mapper.UserRowMapper;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
@@ -11,27 +14,41 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserService {
 
+    private static final Logger log = LoggerFactory.getLogger(UserService.class);
+
     private final JdbcTemplate template;
 
     public User user(final Long userId) {
         try {
-
             return template.queryForObject(
-                "select " +
-                    "id, " +
-                    "firstName, " +
-                    "lastName, " +
-                    "username, " +
-                    "password " +
-                    "from User " +
-                    "where id = ?",
-                new BeanPropertyRowMapper<>(User.class),
+                UserRowMapper.SELECT_QUERY,
+                new UserRowMapper(),
                 userId
             );
         } catch (EmptyResultDataAccessException e) {
             return null;
         }
-
     }
 
+    public void updateUser(Long userId, User user) {
+        String updateStatement = "update User set "
+                + "firstName = ?, "
+                + "lastName = ?, "
+                + "username = ? "
+                + "where id = ?";
+
+        Object[] parameters = new Object[]{
+                user.getFirstName(),
+                user.getLastName(),
+                user.getUsername(),
+                userId
+        };
+
+        try {
+            template.update(updateStatement, parameters);
+        } catch (DataAccessException e) {
+            log.error("Failed to update user", e);
+            throw e;
+        }
+    }
 }

--- a/src/main/resources/db/migration/V1__init_db.sql
+++ b/src/main/resources/db/migration/V1__init_db.sql
@@ -1,13 +1,34 @@
 create table User
 (
-    id        bigint              not null primary key,
-    firstName varchar(255)        not null,
-    lastName  varchar(255)        not null,
-    username  varchar(255) unique not null,
-    password  varchar(255)        not null -- WHAT!? NOT ENCRYPTED!? ;-)
+    id         bigint              not null primary key,
+    firstName  varchar(255)        not null,
+    lastName   varchar(255)        not null,
+    username   varchar(255) unique not null,
+
+    -- hashes are fine: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+    password   varchar(255)        not null, -- WHAT!? NOT ENCRYPTED!? ;-)
+    address_id bigint              not null -- assuming not null
 );
 
-insert into User
-    (id, firstName, lastName, username, password)
-values (1, 'Phil', 'Ingwell', 'PhilIngwell', 'Password123') ,
-    (2, 'Anna', 'Conda', 'AnnaConda', 'Password234');
+create table Address
+(
+    id       bigint       not null primary key,
+    address1 varchar(255) not null,
+    address2 varchar(255),
+    city     varchar(255) not null,
+    state    varchar(100) not null,
+    postal   varchar(10)  not null
+);
+
+alter table User
+    add foreign key (address_id)
+    references Address(id);
+
+insert into Address (id, address1, address2, city, state, postal)
+values (1, '1060 W Addison St', null, 'Chicago', 'IL', '60613'),
+       (2, '1600 Pennsylvania Ave NW', 'Apt 2', 'Washington', 'D.C.', '20500');
+
+insert into User (id, firstName, lastName, username, password, address_id)
+values (1, 'Phil', 'Ingwell', 'PhilIngwell', 'Password123', 1),
+       (2, 'Anna', 'Conda', 'AnnaConda', 'Password234', 2);
+

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -1,2 +1,21 @@
 type Query {
+    user(id: ID!): User
+}
+
+type User {
+    id: ID!,
+    firstName: String!,
+    lastName: String!,
+    username: String!,
+#    password: String, # Should not be visible to users
+    address: Address!
+}
+
+type Address {
+    id: ID!,
+    address1: String!,
+    address2: String,
+    city: String!,
+    state: String!,
+    postal: String!
 }

--- a/src/test/java/com/midwesttape/project/challengeapplication/dao/AddressDaoTest.java
+++ b/src/test/java/com/midwesttape/project/challengeapplication/dao/AddressDaoTest.java
@@ -1,0 +1,24 @@
+package com.midwesttape.project.challengeapplication.dao;
+
+import com.midwesttape.project.challengeapplication.model.Address;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+//@DataJpaTest // If this were a jpa repository the test could be much lighter
+@SpringBootTest
+class AddressDaoTest {
+
+    @Autowired
+    private AddressDao addressDao;
+
+    @Test
+    public void getAddress() {
+        Address address = addressDao.getAddress(1L);
+        assertNotNull(address);
+        assertEquals("1060 W Addison St", address.getAddress1());
+    }
+}

--- a/src/test/java/com/midwesttape/project/challengeapplication/rest/UserControllerTest.java
+++ b/src/test/java/com/midwesttape/project/challengeapplication/rest/UserControllerTest.java
@@ -1,0 +1,57 @@
+package com.midwesttape.project.challengeapplication.rest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void getUserAndAddress() throws Exception {
+        mockMvc.perform(get("/v1/users/{userId}", 1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("Phil"))
+                .andExpect(jsonPath("$.lastName").value("Ingwell"))
+                .andExpect(jsonPath("$.username").value("PhilIngwell"))
+                .andExpect(jsonPath("$.password").doesNotExist())
+                .andExpect(jsonPath("$.address.address1").value("1060 W Addison St"));
+    }
+
+    /**
+     * {@link Transactional} is required since this test updates the in memory database.
+     * {@link Rollback} could be added for clarity too, but since it's unnecessary I left it out.
+     */
+    @Test
+    @Transactional
+    public void updateUser() throws Exception {
+        long userId = 1;
+        String payload = "{\"firstName\":\"Bart\",\"lastName\":\"Simpson\",\"username\":\"bsimpson\"}";
+
+        mockMvc.perform(put("/v1/users/{userId}", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                .content(payload))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/v1/users/{userId}", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("Bart"))
+                .andExpect(jsonPath("$.lastName").value("Simpson"));
+    }
+
+}

--- a/src/test/java/com/midwesttape/project/challengeapplication/service/UserServiceTest.java
+++ b/src/test/java/com/midwesttape/project/challengeapplication/service/UserServiceTest.java
@@ -10,7 +10,9 @@ import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,8 +40,5 @@ class UserServiceTest {
         final User resultUser = userService.user(USER_ID);
 
         assertEquals(user, resultUser);
-
-
     }
-
 }


### PR DESCRIPTION
Challenge notes:
1: I assumed the new address_id column should be `NOT NULL`.
2: I used a join, rather than using a separate `AddressDao` class, and therefore a custom RowMapper was required.
3: I think it should work, my graphql experience is lacking. 
4: Only the `firstName`, `lastName`, and `userName` fields are editable, I forbid updating `id`, `password` and `address` on the update user endpoint.

Other notes:
- passwords no longer serialize (for toString() as well as through jackson)
- [jo](https://github.com/jpmens/jo) is used on a lot of the testing
- a mockMvc test was added
- adding spring-data-jpa, querydsl, and the spring-querydsl dependencies would probably make a sufficient implementation for the graphql schema. I think a newer version of spring-boot would be needed though.